### PR TITLE
Begin version 0.6: more support for project authors to say things about packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,8 @@ jobs:
     install: doit develop_install
     script:
       - doit test_all
-      - conda config --add channels file:///$HOME/miniconda/conda-bld      
+      - conda config --add channels file:///$HOME/miniconda/conda-bld
+      - export PYCTDEV_SELF_CHANNEL="" # so the above channel will be used
       - doit --dir=examples/one test_all
       - doit --dir=examples/one test_export
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 sudo: false
 language: generic
 
@@ -37,10 +38,7 @@ jobs:
   - &pip_default
     stage: test
     # (pyctdev requires itself to test itself)
-    before_install:
-      - pyenv install 3.6.3
-      - pyenv global 3.6.3      
-      - pip install -e .
+    before_install: pip install -e .
     install: doit develop_install
     script:
       - doit test_all
@@ -53,8 +51,6 @@ jobs:
     stage: test
     env: PYCTDEV_ECOSYSTEM=conda
     before_install:
-      - pyenv install 3.6.3
-      - pyenv global 3.6.3
       ## install miniconda (using git pyctdev)
       - pip install -e . && doit miniconda_install && pip uninstall -y doit pyctdev && rm -f .doit.db
       - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: bionic
 language: generic
 
 # quick hack to determine what tag is (improvements welcomed)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: bionic
-sudo: false
 language: generic
 
 # quick hack to determine what tag is (improvements welcomed)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
     # (pyctdev requires itself to test itself)
     before_install:
       - pyenv install 3.6.3
+      - pyenv global 3.6.3      
       - pip install -e .
     install: doit develop_install
     script:
@@ -53,6 +54,7 @@ jobs:
     env: PYCTDEV_ECOSYSTEM=conda
     before_install:
       - pyenv install 3.6.3
+      - pyenv global 3.6.3
       ## install miniconda (using git pyctdev)
       - pip install -e . && doit miniconda_install && pip uninstall -y doit pyctdev && rm -f .doit.db
       - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ jobs:
   - &pip_default
     stage: test
     # (pyctdev requires itself to test itself)
-    before_install: pip install -e .
+    before_install:
+      - pyenv install 3.6.3
+      - pip install -e .
     install: doit develop_install
     script:
       - doit test_all
@@ -50,6 +52,7 @@ jobs:
     stage: test
     env: PYCTDEV_ECOSYSTEM=conda
     before_install:
+      - pyenv install 3.6.3
       ## install miniconda (using git pyctdev)
       - pip install -e . && doit miniconda_install && pip uninstall -y doit pyctdev && rm -f .doit.db
       - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
     script:
       - doit test_all
       - doit --dir=examples/one test_all
+      #- doit --dir=examples/two test_all
 
   ## conda
 
@@ -64,7 +65,8 @@ jobs:
       - export PYCTDEV_SELF_CHANNEL="" # so the above channel will be used
       - doit --dir=examples/one test_all
       - doit --dir=examples/one test_export
-
+      # TODO: still need to update conda stuff e.g. remove recipe
+      - doit --dir=examples/two test_export
 
   ########## BUILD/TEST/UPLOAD END-USER PACKAGES ##########
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: generic
 
 env:
   global:
-    - PYENV_VERSION=3.6
+    - PYENV_VERSION=3.7
     - PKG_TEST_GROUP="--test-group=all"
     - CHANS_DEV="-c pyviz/label/dev"
     - CHANS_REL="-c pyviz"
@@ -85,7 +85,7 @@ jobs:
     script: doit package_upload -u ceball -p $PYPIPWD --pypi ${PYPI}
 
   - <<: *pip_pkg_default
-    env: PYENV_VERSION=3.6 PYPI=testpypi
+    env: PYENV_VERSION=3.7 PYPI=testpypi
 
   - <<: *pip_pkg_default
     stage: pip_package
@@ -93,7 +93,7 @@ jobs:
 
   - <<: *pip_pkg_default
     stage: pip_package
-    env: PYENV_VERSION=3.6 PYPI=pypi
+    env: PYENV_VERSION=3.7 PYPI=pypi
 
 
   ##### conda

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,5 @@ include LICENSE
 include README.md
 include pyctdev/_version.py
 include pyctdev/_vendor/*.*
+include pyctdev/condatemplate.yaml
 include tox.ini

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
-  build:
+  host:
     - python
     - setuptools
   run:

--- a/examples/one/tests/testA.yaml
+++ b/examples/one/tests/testA.yaml
@@ -2,5 +2,5 @@ name: _pyctdev_test_one
 channels:
   - defaults
 dependencies:
-  - holoviews=1.10.0
-  - hypothesis=3.56.0
+  - pkgs/main::holoviews=1.10.0
+  - pkgs/main::hypothesis=3.56.0

--- a/examples/one/tox.ini
+++ b/examples/one/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}-{unit,flakes,examples,all,export}-{default,with_numpy}-{dev}
+envlist = {py27,py36,py37}-{unit,flakes,examples,all,export}-{default,with_numpy}-{dev}
 
 [_flakes]
 commands = flake8

--- a/examples/two/conda.recipe/meta.yaml
+++ b/examples/two/conda.recipe/meta.yaml
@@ -1,0 +1,35 @@
+{% set sdata = load_setup_py_data() %}
+
+package:
+  name: two
+  version: {{ sdata['version'] }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+  run:
+    - python {{ sdata['python_requires'] }}
+    {% for dep in sdata.get('install_requires',{}) %}
+    - "{{ dep }}"
+    {% endfor %}
+
+test:
+  imports:
+    - two
+  requires:
+    {% for dep in sdata['extras_require']['tests'] %}
+    - "{{ dep }}"
+    {% endfor %}    
+
+about:
+  home: {{ sdata['url'] }}
+  summary: {{ sdata['description'] }}
+  license: {{ sdata['license'] }}

--- a/examples/two/dodo.py
+++ b/examples/two/dodo.py
@@ -1,0 +1,1 @@
+from pyctdev import *  # noqa: api

--- a/examples/two/setup.cfg
+++ b/examples/two/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = two
+version = 0.0.1
+description = Some test project
+url = http://localhost
+license = BSD
+
+[options]
+include_package_data = True
+packages = find:
+python_requires = >=2.7
+# just examples
+# TODO: need a [] without a version to test cb dropping as selector
+install_requires =
+    hypothesis[numpy] <3.57.0
+
+[options.extras_require]
+tests =
+    flake8
+
+examples =
+    # pulls in other deps and pinned (both deliberate, for testing)
+    holoviews[recommended] <=1.10.0
+
+[tool:pyctdev]
+pins =
+    holoviews = 1.10.0
+    hypothesis = 3.56.0
+
+[wheel]
+universal = 1
+

--- a/examples/two/setup.py
+++ b/examples/two/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+if __name__=="__main__":
+    setup()

--- a/examples/two/tests/testA.yaml
+++ b/examples/two/tests/testA.yaml
@@ -1,0 +1,4 @@
+name: _pyctdev_test_two
+dependencies:
+  - holoviews ==1.10.0
+  - hypothesis ==3.56.0

--- a/examples/two/tox.ini
+++ b/examples/two/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py36}-{unit,flakes,examples,all,export}-{default,with_numpy}-{dev}
+envlist = {py27,py36,py37}-{unit,flakes,examples,all,export}-{default,with_numpy}-{dev}
 
 [_flakes]
 commands = flake8

--- a/examples/two/tox.ini
+++ b/examples/two/tox.ini
@@ -1,0 +1,50 @@
+[tox]
+envlist = {py27,py36}-{unit,flakes,examples,all,export}-{default,with_numpy}-{dev}
+
+[_flakes]
+commands = flake8
+deps = .[tests]
+
+[_unit]
+commands = python -c "print('unit')"
+deps = .[tests]
+
+[_examples]
+commands = python -c "print('examples')"
+deps = .[examples, tests]
+
+; see https://github.com/pyviz/pyct/issues/14
+[_export]
+; doit ecosystem=conda env_export2 --env-name _pyctdev_test_two --env-file pyctdev_test_two.yaml --env-name-again _pyctdev_test_two --options examples env_create --name _pyctdev_test_two --pin-deps
+commands = doit ecosystem=conda env_export2 --env-name _pyctdev_test_two --env-file pyctdev_test_two.yaml --env-name-again _pyctdev_test_two --options examples --pin-deps --no-advert
+           python -c "import filecmp; gen=open('pyctdev_test_two.yaml').read(); ref=open('tests/testA.yaml').read(); assert filecmp.cmp('pyctdev_test_two.yaml','tests/testA.yaml'), 'Generated file...\n'+gen+'\n...failed to match reference...\n'+ref"
+
+[_all]
+commands = {[_flakes]commands}
+           {[_unit]commands}
+           {[_examples]commands}
+deps = .[examples, tests]
+
+
+[testenv]
+changedir = {envtmpdir}
+
+commands = unit: {[_unit]commands}
+           flakes: {[_flakes]commands}
+           all: {[_all]commands}
+           examples: {[_examples]commands}
+           with_numpy: python -c "import numpy;print(numpy.__version__)"
+           export: {[_export]commands}
+
+deps = unit: {[_unit]deps}
+       flakes: {[_flakes]deps}
+       examples: {[_examples]deps}
+       all: {[_all]deps}
+       with_numpy: numpy
+       export: {[_all]deps}
+
+
+[flake8]
+ignore = E,W
+include = *.py
+exclude = .git,__pycache__,.tox,.eggs,*.egg,docs,dist,build,_build,.ipynb_checkpoints,run_test.py

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -185,8 +185,16 @@ def task_env_export2():
         'type':str,
         'default':''}
 
+    no_advert = {
+        'name':'no_advert',
+        'long':'no-advert',
+        'type':bool,
+        'default':True,
+        'inverse':'advert'
+    }
+
     
-    def x(no_pin_deps,package_name,options2,channel,all_extras,env_file,env_name_again):
+    def x(no_pin_deps,package_name,options2,channel,all_extras,env_file,env_name_again,no_advert):
         from conda_env.env import Environment
 
         options = set(options2).union(set(read_conda_packages('setup.cfg',package_name)))
@@ -205,15 +213,16 @@ def task_env_export2():
 
         e.save()
 
-        # hack in link back
-        with open(env_file,'r+') as f:
-            content = f.read()
-            f.seek(0)
-            # probably more useful info could be put here
-            f.write("# file created by pyctdev:\n#   " + " ".join(sys.argv) + "\n\n" + content)
+        if not no_advert:
+            # hack in link back
+            with open(env_file,'r+') as f:
+                content = f.read()
+                f.seek(0)
+                # probably more useful info could be put here
+                f.write("# file created by pyctdev:\n#   " + " ".join(sys.argv) + "\n\n" + content)
         
     return {'actions':[x],
-            'params': [_options_param2,_channel_param,_all_extras_param,no_pin_deps,package_name,env_file,env_name_again]
+            'params': [_options_param2,_channel_param,_all_extras_param,no_pin_deps,package_name,env_file,env_name_again,no_advert]
     }
 
 

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -3,6 +3,20 @@ Tasks for conda world
 
 """
 
+# TODO: conda env file/package generation: sort within each section (e.g. run dependencies, build dependencies)
+
+# TODO: pkg name addition needs to support multiple packages e.g. gv gv-core
+
+# TODO: pkg name addition needs to support existing recipe if present
+
+# TODO: clean up list v. string form for _pin
+
+# TODO: be able to generate env file (not just env)
+
+# TODO: no support for pin deps etc in pip
+
+# pip can install an "env" from remote file; what about conda?
+
 # note: conda's api at https://github.com/conda/conda/issues/7059
 
 # TODO: move tasks to conda.py and leave hacks here.
@@ -12,6 +26,8 @@ import os
 import glob
 import json
 import re
+import sys
+import warnings
 try:
     from urllib.request import urlretrieve
 except ImportError:
@@ -28,9 +44,13 @@ except ImportError:
     yaml = None
 
 from doit.action import CmdAction
-from .util import _options_param, test_python, test_group, test_requires, get_tox_deps, get_tox_cmds, get_tox_python, get_env, pkg_tests, test_matrix, echo, get_buildreqs
-
+from .util import _options_param,_options_param2, test_python, test_group, test_requires, get_tox_deps, get_tox_cmds, get_tox_python, get_env, pkg_tests, test_matrix, echo, get_buildreqs, read_pins, read_conda_packages,_all_extras_param
 # TODO: for caching env on travis, what about links? option to copy?
+
+try:
+    from conda.models.match_spec import MatchSpec
+except ImportError:
+    pass # TODO: things will go wrong later...
 
 
 ########## UTIL/CONFIG ##########
@@ -53,6 +73,12 @@ env_name_again = {
     'default':''}
 ##
 
+package_name = {'name':'package_name',
+                'long':'package-name',
+                'type':str,
+                'default':'' }
+
+
 _channel_param = {
     'name':'channel',
     'long':'channel',
@@ -62,6 +88,16 @@ _channel_param = {
                  # typically what comes with ana/miniconda)...is that
                  # what we want?
 }
+
+# TODO: pinning not supported for pip world yet
+no_pin_deps = {
+    'name':'no_pin_deps',
+    'long':'no-pin-deps',
+    'type':bool,
+    'default':True,
+    'inverse':'pin-deps'
+}
+
 
 # TODO: not sure what conda-using developers do/prefer...
 # pip develop and don't install missing deps
@@ -84,9 +120,38 @@ def _conda_build_deps(channel):
         return echo("Skipping conda install (no build dependencies)")
     
 
-def _conda_install_with_options(options,channel,env_name_again):
-    deps = get_dependencies(['install_requires']+options)
+def _pin(deps):
+
+    pins = read_pins('setup.cfg')
+    if len(pins)==0:
+        warnings.warn("Pins requested, but no pins in setup.cfg")
+        return
+
+    try:
+        pinned_but_missing = set(pins).difference(set([MatchSpec(d).name for d in deps]))
+    except:
+        import pdb;pdb.set_trace()
+
+    if len(pinned_but_missing)!=0:
+        raise ValueError("Pins specified for non-existent dependencies %s"%pinned_but_missing)
+    pinneddeps = []    
+    for d in deps:
+        dname = MatchSpec(d).name
+        if dname in pins:
+            pinneddeps.append("%s ==%s"%(dname,pins[dname]))
+        else:
+            pinneddeps.append("%s"%d)
+    return pinneddeps
+
+    
+def _conda_install_with_options(options,channel,env_name_again,no_pin_deps,all_extras):
+    # TODO: list v string form for _pin
+    deps = _get_dependencies(['install_requires']+options,all_extras=all_extras)
+
     if len(deps)>0:
+        deps = _pin(deps) if no_pin_deps is False else deps
+        deps = " ".join('"%s"'%dep for dep in deps)       
+        # TODO and join the club? 
         e = '' if env_name_again=='' else '-n %s'%env_name_again
         return "conda install -y " + e + " %s %s"%(" ".join(['-c %s'%c for c in channel]),deps)
     else:
@@ -94,8 +159,8 @@ def _conda_install_with_options(options,channel,env_name_again):
 
 
 # TODO: another parameter workaround
-def _conda_install_with_options_hacked(options,channel):
-    return _conda_install_with_options(options,channel,'')
+def _conda_install_with_options_hacked(options,channel,no_pin_deps,all_extras):
+    return _conda_install_with_options(options,channel,'',no_pin_deps,all_extras)
 
 ############################################################
 # TASKS...
@@ -106,6 +171,52 @@ def _conda_install_with_options_hacked(options,channel):
 def task_env_capture():
     """Report all information required to recreate current conda environment"""
     return {'actions':["conda info","conda list","conda env export"]}
+
+def task_env_export2():
+
+    # TODO: support channel pins too maybe. Either as a separate thing that can
+    # also be requested (like version pins), or maybe just use channel::pkg in
+    # pins?
+
+    # TODO: required, rename, friendlier
+    env_file = {
+        'name':'env_file',
+        'long':'env-file',
+        'type':str,
+        'default':''}
+
+    
+    def x(no_pin_deps,package_name,options2,channel,all_extras,env_file,env_name_again):
+        from conda_env.env import Environment
+
+        options = set(options2).union(set(read_conda_packages('setup.cfg',package_name)))
+        deps = [d for d in _get_dependencies(['install_requires']+list(options),all_extras=all_extras)]
+
+        if no_pin_deps is False:
+            deps = _pin(deps)
+
+        deps = [_join_the_club(d) for d in deps]
+            
+        e = Environment(
+            name=env_name_again,
+            channels=channel,
+            filename = env_file,
+            dependencies=sorted(deps))
+
+        e.save()
+
+        # hack in link back
+        with open(env_file,'r+') as f:
+            content = f.read()
+            f.seek(0)
+            # probably more useful info could be put here
+            f.write("# file created by pyctdev:\n#   " + " ".join(sys.argv) + "\n\n" + content)
+        
+    return {'actions':[x],
+            'params': [_options_param2,_channel_param,_all_extras_param,no_pin_deps,package_name,env_file,env_name_again]
+    }
+
+
 
 def task_env_export():
     """
@@ -130,7 +241,7 @@ def task_env_export():
         'type':str,
         'default':''}
 
-    def x(env_name,options,env_file):
+    def x(env_name,options,env_file,all_extras):
         import collections
         from conda_env.env import from_environment
         from conda.cli.python_api import Commands, run_command
@@ -141,7 +252,7 @@ def task_env_export():
         E = from_environment(env_name, prefix, no_builds=True, ignore_channels=False)
         from conda.models.match_spec import MatchSpec
 
-        deps = set([MatchSpec(d).name for d in _get_dependencies(['install_requires']+options)])
+        deps = set([MatchSpec(d).name for d in _get_dependencies(['install_requires']+options,all_extras=all_extras)])
         
         for what in E.dependencies:                    
             E.dependencies[what] = [d for d in E.dependencies[what] if MatchSpec(d).name in deps]
@@ -170,13 +281,13 @@ def task_env_export():
         CmdAction(_hacked_conda_install_with_options),
         x],
             'task_dep': ['env_create'],
-            'params': [env_name, _options_param, env_file, env_name_again,_options_param,_channel_param]}
+            'params': [env_name, _options_param, env_file, env_name_again,_options_param,_channel_param,_all_extras_param]}
 
 # because of default options value...removing 'tests'
-def _hacked_conda_install_with_options(task,options,channel,env_name_again):
+def _hacked_conda_install_with_options(task,options,channel,env_name_again,all_extras):
     if 'tests' in task.options.get('options',[]):
         task.options['options'].remove('tests')
-    return _conda_install_with_options(options,channel,env_name_again)
+    return _conda_install_with_options(options,channel,env_name_again,all_extras)
 
 miniconda_url = {
     "Windows": "https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe",
@@ -392,39 +503,71 @@ def task_package_build():
     # hacks to get a quick version of
     # https://github.com/conda/conda-build/issues/2648
 
-
+    
     pin_deps_as_env = {
         'name':'pin_deps_as_env',
         'long':'pin-deps-as-env',
         'type':str,
         'default':''}
 
-    
-    def create_recipe_clobber(recipe,pin_deps_as_env):
-        if pin_deps_as_env == '':
+    def create_base_recipe(package_name):
+
+        if package_name=='':
+            return
+        
+        # read from setup.cfg
+        extras = str(read_conda_packages('setup.cfg',package_name))
+        
+#        assert package_name in setup.cfg
+        r = open(os.path.join(os.path.dirname(__file__),"condatemplate.yaml")).read()
+
+        # hack https://github.com/conda/conda-build/issues/2475
+        r = r.replace(r"{{ pname }}",package_name)
+        
+
+        if not os.path.exists("conda.recipe"): # could do better/race
+            os.makedirs("conda.recipe")
+
+        with open("conda.recipe/meta.yaml",'w') as f:
+            f.write("{%% set pname = %s %%}\n"%package_name)
+            f.write("{%% set extras = %s %%}\n"%extras)
+            buildreqs = get_buildreqs()
+            buildeps = "["+ ",".join('"%s"'%dep for dep in buildreqs) + "]"
+            f.write("{%% set builddeps = %s %%}\n"%buildeps)
+            f.write(r)
+
+            
+    def create_recipe_clobber(recipe,pin_deps_as_env,no_pin_deps,package_name):
+        from conda.models.match_spec import MatchSpec            
+        
+        if pin_deps_as_env == '' and no_pin_deps is True:
             return
         else:
-            requirements_run = []
-            
-            # TODO: unify with conda in env_export
-            env_name = pin_deps_as_env
-            import collections
-            from conda.cli.python_api import Commands, run_command
-            env_names = [(os.path.basename(e),e) for e in json.loads(run_command(Commands.INFO,"--json")[0])['envs']]
-            counts = collections.Counter([x[0] for x in env_names])
-            assert counts[env_name]==1 # would need more than name to be sure...
-            prefix = dict(env_names)[env_name]
-
-            packages = json.loads(run_command(Commands.LIST,"-p %s --json"%prefix)[0])
-            packagesd = {package['name']:package for package in packages}
-
-            deps = _get_dependencies(['install_requires'])
+            extras = read_conda_packages('setup.cfg',package_name)
+            deps = _get_dependencies(['install_requires']+extras)
             deps = [_join_the_club(d) for d in deps]
 
-            # TODO: could add channel to the pin...
-            from conda.models.match_spec import MatchSpec
-            requirements_run = ["%s ==%s"%(MatchSpec(d).name,packagesd[MatchSpec(d).name]['version']) for d in deps]
-                        
+            if pin_deps_as_env != '':
+                assert no_pin_deps is True
+                # TODO: unify with conda in env_export
+                env_name = pin_deps_as_env
+                import collections
+                from conda.cli.python_api import Commands, run_command
+                env_names = [(os.path.basename(e),e) for e in json.loads(run_command(Commands.INFO,"--json")[0])['envs']]
+                counts = collections.Counter([x[0] for x in env_names])
+                assert counts[env_name]==1 # would need more than name to be sure...
+                prefix = dict(env_names)[env_name]
+    
+                packages = json.loads(run_command(Commands.LIST,"-p %s --json"%prefix)[0])
+                packagesd = {package['name']:package for package in packages}
+        
+                # TODO: could add channel to the pin...
+                requirements_run = ["%s ==%s"%(MatchSpec(d).name,packagesd[MatchSpec(d).name]['version']) for d in deps]
+                
+            else:
+                requirements_run = _pin(deps)
+                
+                            
             with open("conda.recipe/%s/_pyctdev_recipe_clobber.yaml"%recipe,'w') as f:
                 f.write(yaml.dump(
                     {
@@ -442,21 +585,21 @@ def task_package_build():
         else:
             return 'echo "no build reqs"'    
     
-    def thing(channel,pin_deps_as_env,recipe):
+    def thing(channel,pin_deps_as_env,recipe,no_pin_deps):
         cmd = "conda build %s conda.recipe/%s"%(" ".join(['-c %s'%c for c in channel]),
                                                  "%(recipe)s")
-        if pin_deps_as_env != '':
+        if pin_deps_as_env != '' or no_pin_deps is False:
             cmd += " --clobber-file conda.recipe/%s/_pyctdev_recipe_clobber.yaml"%recipe
         return cmd
 
-    def thing2(channel,pkg_tests,test_python,test_group,test_requires,recipe,pin_deps_as_env):
+    def thing2(channel,pkg_tests,test_python,test_group,test_requires,recipe,pin_deps_as_env,no_pin_deps):
         cmds = []
         if pkg_tests:
             # TODO: should test groups just be applied across others rather than product?
             # It's about test isolation vs speed of running tests...
             for (p,g,r,w) in test_matrix(test_python,test_group,test_requires,['pkg']):
                 cmds.append(
-                    thing(channel,pin_deps_as_env,recipe)+" -t --append-file conda.recipe/%s/recipe_append--%s-%s-%s-%s.yaml"%("%(recipe)s",p,g,r,w)
+                    thing(channel,pin_deps_as_env,recipe,no_pin_deps)+" -t --append-file conda.recipe/%s/recipe_append--%s-%s-%s-%s.yaml"%("%(recipe)s",p,g,r,w)
                     )
                 cmds.append("conda build purge") # remove test/work intermediates (see same comment below)
         # hack again for returning variable number of commands...
@@ -510,9 +653,11 @@ def task_package_build():
                 pass
 
     return {'actions': [
-        create_recipe_clobber,
         # 0. install build requirements (conda build doesn't support pyproject.toml/PEP518
         CmdAction(thing0),
+
+        create_base_recipe,
+        create_recipe_clobber,
         # first build the package...
         CmdAction(thing),
         "conda build purge", # remove test/work intermediates (disk space on travis...but could potentially annoy someone as it'll remove other test/work intermediates too...)
@@ -523,7 +668,7 @@ def task_package_build():
         CmdAction(thing2),
     ],
             'teardown': [remove_recipe_append_and_clobber],
-            'params': [_channel_param, recipe_param, test_python, test_group, test_requires, pkg_tests, pin_deps_as_env]}
+            'params': [_channel_param, recipe_param, test_python, test_group, test_requires, pkg_tests, pin_deps_as_env,no_pin_deps,package_name]}
 
 
 
@@ -667,7 +812,7 @@ def task_develop_install():
         CmdAction(_conda_build_deps),
         CmdAction(_conda_install_with_options_hacked),
         python_develop],
-            'params': [_options_param,_channel_param]}
+            'params': [_options_param,_channel_param,no_pin_deps,_all_extras_param]}
 
 
 def task_env_dependency_graph():

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -77,6 +77,7 @@ env_name_again = {
     'default':''}
 ##
 
+# this is about selecting groups of optional extras
 package_name = {'name':'package_name',
                 'long':'package-name',
                 'type':str,
@@ -542,17 +543,32 @@ def task_package_build():
         'type':str,
         'default':''}
 
-    def create_base_recipe(package_name):
+    force = {
+        'name':'force',
+        'long':'force',
+        'type':bool,
+        'default':False}
+
+    
+    def create_base_recipe(package_name,force):
 
         # TODO: need to replace this with checking for existing recipe and using that.
         # and fall back to package name in normal setup.cfg
-        if package_name=='':
+        if os.path.exists("conda.recipe/meta.yaml") and not force:
+            print("conda.recipe/meta.yaml exists; not overwriting without --force")
             return
-        
+
+        # TODO: should support setup.py too
+        import setuptools.config
+        cfg = setuptools.config.read_configuration("setup.cfg")
+        try:
+            package_name = cfg['metadata']['name']
+        except:
+            raise ValueError("--package-name not supplied and not found in setup.cfg")
+
         # read from setup.cfg
         extras = str(read_conda_packages('setup.cfg',package_name))
         
-#        assert package_name in setup.cfg
         r = open(os.path.join(os.path.dirname(__file__),"condatemplate.yaml")).read()
 
         # hack https://github.com/conda/conda-build/issues/2475
@@ -700,7 +716,7 @@ def task_package_build():
         CmdAction(thing2),
     ],
             'teardown': [remove_recipe_append_and_clobber],
-            'params': [_channel_param, recipe_param, test_python, test_group, test_requires, pkg_tests, pin_deps_as_env,no_pin_deps,package_name]}
+            'params': [_channel_param, recipe_param, test_python, test_group, test_requires, pkg_tests, pin_deps_as_env,no_pin_deps,package_name, force]}
 
 
 

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -130,7 +130,7 @@ def _pin(deps):
     pins = { _join_the_club(d):pins[d] for d in pins }
     if len(pins)==0:
         warnings.warn("Pins requested, but no pins in setup.cfg")
-        return
+        return deps
 
     deps = [_join_the_club(d) for d in deps]
 
@@ -544,6 +544,8 @@ def task_package_build():
 
     def create_base_recipe(package_name):
 
+        # TODO: need to replace this with checking for existing recipe and using that.
+        # and fall back to package name in normal setup.cfg
         if package_name=='':
             return
         

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -117,7 +117,7 @@ from .util import _get_dependencies
 
 def _conda_build_deps(channel):
     buildreqs = get_buildreqs()
-    deps = " ".join('"%s"'%dep for dep in buildreqs)
+    deps = " ".join('"%s"'%_join_the_club(dep) for dep in buildreqs)
     if len(buildreqs)>0:
         return "conda install -y %s %s"%(" ".join(['-c %s'%c for c in channel]),deps)
     else:
@@ -564,7 +564,7 @@ def task_package_build():
             f.write("{%% set pname = %s %%}\n"%package_name)
             f.write("{%% set extras = %s %%}\n"%extras)
             buildreqs = get_buildreqs()
-            buildeps = "["+ ",".join('"%s"'%dep for dep in buildreqs) + "]"
+            buildeps = "["+ ",".join('"%s"'%_join_the_club(dep) for dep in buildreqs) + "]"
             f.write("{%% set builddeps = %s %%}\n"%buildeps)
             f.write(r)
 
@@ -610,7 +610,7 @@ def task_package_build():
     def thing0(channel):
         buildreqs = get_buildreqs()
         if len(buildreqs)>0:
-            deps = " ".join('"%s"'%dep for dep in buildreqs)
+            deps = " ".join('"%s"'%_join_the_club(dep) for dep in buildreqs)
             return "conda install -y %s %s"%(" ".join(['-c %s'%c for c in channel]),deps)
         else:
             return 'echo "no build reqs"'    

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -3,6 +3,10 @@ Tasks for conda world
 
 """
 
+# TODO: must have already said this somewhere, but the parameter
+# handling is a nightmare. For so many reasons. Like when chaining
+# tasks, all must support the same parameters.
+
 # TODO: conda env file/package generation: sort within each section (e.g. run dependencies, build dependencies)
 
 # TODO: pkg name addition needs to support multiple packages e.g. gv gv-core
@@ -290,13 +294,13 @@ def task_env_export():
         CmdAction(_hacked_conda_install_with_options),
         x],
             'task_dep': ['env_create'],
-            'params': [env_name, _options_param, env_file, env_name_again,_options_param,_channel_param,_all_extras_param]}
+            'params': [env_name, _options_param, env_file, env_name_again,_options_param,_channel_param,_all_extras_param, no_pin_deps]}
 
 # because of default options value...removing 'tests'
-def _hacked_conda_install_with_options(task,options,channel,env_name_again,all_extras):
+def _hacked_conda_install_with_options(task,options,channel,env_name_again,no_pin_deps,all_extras):
     if 'tests' in task.options.get('options',[]):
         task.options['options'].remove('tests')
-    return _conda_install_with_options(options,channel,env_name_again,all_extras)
+    return _conda_install_with_options(options,channel,env_name_again,no_pin_deps,all_extras)
 
 miniconda_url = {
     "Windows": "https://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe",

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -193,7 +193,7 @@ def task_env_export2():
         'name':'no_advert',
         'long':'no-advert',
         'type':bool,
-        'default':True,
+        'default':False,
         'inverse':'advert'
     }
 

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -109,7 +109,7 @@ python_develop = "pip install --no-deps -e ."
 # setuptools develop and easy_install missing deps:
 #  python_develop = "python setup.py develop"
 
-from .util import get_dependencies,_get_dependencies
+from .util import _get_dependencies
 
 def _conda_build_deps(channel):
     buildreqs = get_buildreqs()

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -151,6 +151,7 @@ def _pin(deps):
 def _conda_install_with_options(options,channel,env_name_again,no_pin_deps,all_extras):
     # TODO: list v string form for _pin
     deps = _get_dependencies(['install_requires']+options,all_extras=all_extras)
+    deps = [_join_the_club(d) for d in deps]
 
     if len(deps)>0:
         deps = _pin(deps) if no_pin_deps is False else deps

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -275,7 +275,7 @@ def task_env_export():
         # fix up conda channels TODO: should probably just use non-env
         # commands all along instead of conda env
         if 'conda' in E.dependencies:
-            packages = {package['name']:package for package in json.loads(run_command(Commands.LIST,"-p %s --json"%prefix)[0])}
+            packages = {package['name']:package for package in json.loads(run_command(Commands.LIST,"-p", prefix, "--json")[0])}
             E.dependencies['conda'] = ["%s%s"%( (packages[MatchSpec(x).name]['channel']+"::" if packages[MatchSpec(x).name]['channel']!="defaults" else '') ,x) for x in E.dependencies['conda']]
             E.channels = ["defaults"]
 

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -752,8 +752,12 @@ def task_env_create():
         selfchan = "pyviz"
         if Version(__version__).is_prerelease:
             selfchan+="/label/dev"
+        if "PYCTDEV_SELF_CHANNEL" in os.environ:
+            selfchan=os.environ["PYCTDEV_SELF_CHANNEL"]
 
-        return "conda install -y --name %(name)s -c " + selfchan + " pyctdev"
+        if selfchan!="":
+            selfchan = " -c " + selfchan
+        return "conda install -y --name %(name)s " + selfchan + " pyctdev"
     
     
     return {

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -48,7 +48,7 @@ except ImportError:
     yaml = None
 
 from doit.action import CmdAction
-from .util import _options_param,_options_param2, test_python, test_group, test_requires, get_tox_deps, get_tox_cmds, get_tox_python, get_env, pkg_tests, test_matrix, echo, get_buildreqs, read_pins, read_conda_packages,_all_extras_param
+from .util import _options_param,_options_param2, test_python, test_group, test_requires, get_tox_deps, get_tox_cmds, get_tox_python, get_env, pkg_tests, test_matrix, echo, get_buildreqs, read_pins, read_conda_packages,_all_extras_param, read_conda_namespace_map
 # TODO: for caching env on travis, what about links? option to copy?
 
 try:
@@ -406,10 +406,20 @@ def _join_the_club(dep):
     new = re.sub(r'\[.*?\]','',dep)
     # not much point warning only here, since it happens in other places too
     #if new!=dep:warnings.warn("Changed your dep from %s to %s"%(dep,new))
+
+    # should be read just once rather than for each dep!
+    nsmap = read_conda_namespace_map('setup.cfg')
+
     ms = MatchSpec(new)
-    out = "%s"%ms.name
+    out = "%s"%nsmap.get(ms.name,ms.name)
     if ms.version is not None:
-        out+= " %s"%ms.version
+        # why it doesn't include == already?
+        if '==' in new:
+            assert "===" not in new # sorry
+            out+= " =="
+        else:
+            out+= " "
+        out+= "%s"%ms.version
     return out
 
 

--- a/pyctdev/_pip.py
+++ b/pyctdev/_pip.py
@@ -7,7 +7,7 @@ import warnings
 
 from doit.action import CmdAction
 
-from .util import _options_param, test_group, get_env, test_python, test_requires, pkg_tests, test_matrix, echo, get_buildreqs, _all_extras_param
+from .util import _options_param, test_group, get_env, test_python, test_requires, pkg_tests, test_matrix, echo, get_buildreqs, _all_extras_param, _get_setup_metadata
 
 # TODO: move tasks to pip.py and leave hacks here.
 

--- a/pyctdev/_pip.py
+++ b/pyctdev/_pip.py
@@ -33,7 +33,7 @@ _channel_param = {
 }
 
 def _pip_install_with_options(options,channel,all_extras):
-    cmd = "pip install --upgrade " 
+    cmd = "pip install --upgrade "
 
     if 'testpypi' in channel:
         # note: should pre always be used maybe? Or more likely,
@@ -82,11 +82,9 @@ def task_env_capture():
 def task_ecosystem_setup():
     """Common pip setup
 
-    Updates to latest pip, tox, twine, and wheel.
+    Updates to latest tox, twine, and wheel.
     """
-    # TODO: will need to become something like the following w/ pip10
-    # d:\python36\python.exe -m pip install --upgrade pip tox twine wheel
-    return {'actions': ["pip install --upgrade pip tox twine wheel"]}
+    return {'actions': ["pip install --upgrade tox twine wheel"]}
 
 
 ########## PACKAGING ##########
@@ -97,7 +95,7 @@ def task_package_build():
     """Build pip package, then install and test all_quick (or other
     specified env) in venv
 
-    E.g. 
+    E.g.
 
     ``doit package_build --formats=bdist_wheel``
     ``doit package_build -e all_quick-Ewith_numpy``
@@ -126,7 +124,7 @@ def task_package_build():
         'default':'sdist --formats=gztar bdist_wheel --universal'
     }
     # TODO: missing support for pypi channels
-    
+
     def thing(test_group,test_python,test_requires,pkg_tests,sdist=False):
         if pkg_tests:
             enviros = []
@@ -154,7 +152,7 @@ def task_package_build():
                 return echo("not running sdist tests")
         else:
             return echo("no sdist")
-        
+
     def sdist_build_deps(formats,sdist_install_build_deps):
         if 'sdist' in formats:
             if not sdist_install_build_deps:
@@ -172,7 +170,7 @@ def task_package_build():
 
 
     # TODO: would be able to use the packages created by tox if
-    # https://github.com/tox-dev/tox/issues/232 were done    
+    # https://github.com/tox-dev/tox/issues/232 were done
     return {'actions': [CmdAction(wheel),
                         CmdAction(sdist_build_deps),
                         CmdAction(sdist),
@@ -205,7 +203,7 @@ def task_package_upload():
         'type':str,
         'default':''
     }
-    
+
     pypi = {
         'name':'pypi',
         'long':'pypi',
@@ -242,15 +240,15 @@ def task_env_create():
 
 def task_develop_install():
     """python develop install with specified optional groups of dependencies.
-    
-    Typically ``pip install -e .[tests]``. 
+
+    Typically ``pip install -e .[tests]``.
 
     Pass --options multiple times to specify other optional groups
     (see project's setup.py for available options).
 
     Pass --channel multiple times to specify other pypi servers.
 
-    E.g. 
+    E.g.
 
     ``doit develop_install -o examples -o tests``
     ``doit develop_install -o all``

--- a/pyctdev/_pip.py
+++ b/pyctdev/_pip.py
@@ -7,7 +7,7 @@ import warnings
 
 from doit.action import CmdAction
 
-from .util import _options_param, test_group, get_env, test_python, test_requires, pkg_tests, test_matrix, echo, get_buildreqs
+from .util import _options_param, test_group, get_env, test_python, test_requires, pkg_tests, test_matrix, echo, get_buildreqs, _all_extras_param
 
 # TODO: move tasks to pip.py and leave hacks here.
 
@@ -32,7 +32,7 @@ _channel_param = {
                  # pypi.org)...is that what we want?
 }
 
-def _pip_install_with_options(options,channel):
+def _pip_install_with_options(options,channel,all_extras):
     cmd = "pip install --upgrade " 
 
     if 'testpypi' in channel:
@@ -57,7 +57,12 @@ def _pip_install_with_options(options,channel):
     cmd += " ".join(['--extra-index-url=%s '%server for server in servers[1::]])
 
     cmd += "-e ."
-    
+
+    if all_extras:
+        meta = _get_setup_metadata()
+        extras = meta.get('extras_require',{})
+        options = set(options).union(set(extras))
+
     if len(options)>0:
         cmd+="[%s]"%(",".join(options))
     return cmd
@@ -253,7 +258,7 @@ def task_develop_install():
 
     """
     return {'actions': [CmdAction(_pip_install_with_options)],
-            'params':[_options_param,_channel_param]}
+            'params':[_options_param,_channel_param,_all_extras_param]}
 
 ## TODO: keep?
 #

--- a/pyctdev/condatemplate.yaml
+++ b/pyctdev/condatemplate.yaml
@@ -1,0 +1,50 @@
+{% set sdata = load_setup_py_data() %}
+
+package:
+  name: {{ pname }}
+  version: {{ sdata['version'] }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  entry_points:
+    {% for group,epoints in sdata.get("entry_points",{}).items() %}
+    {% for entry_point in epoints %}
+    - {{ entry_point }}
+    {% endfor %}
+    {% endfor %}
+
+requirements:
+  build:
+    {% for dep in builddeps %}
+    - "{{ dep }}"
+    {% endfor %}
+    
+  run:
+    - python {{ sdata.get('python_requires','') }}
+
+    {% for dep in sdata.get('install_requires',[]) %}
+    - "{{ dep }}"
+    {% endfor %}
+
+    {% for extra in extras %}
+     {% for dep in sdata.get('extras_require',{}).get(extra,[]) %}
+    - "{{ dep }}"
+     {% endfor %}
+    {% endfor %}
+
+test:
+  imports:
+    - {{ pname }}
+  requires:
+    {% for dep in sdata['extras_require']['tests'] %}
+    - "{{ dep }}"
+    {% endfor %}
+
+about:
+  home: {{ sdata['url'] }}
+  summary: {{ sdata['description'] }}
+  license: {{ sdata['license'] }}

--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -217,7 +217,11 @@ def get_buildreqs():
     return buildreqs
 
 
-# TODO: can i use more of setuptools config parsing?
+# TODO: can i use more of setuptools config parsing?  There was some
+# reason I didn't use setuptools.config.read_configuration, but I
+# can't remember what it was now. (I think it was to do with needing a
+# % sign for the git format (autover), but that breaking some version
+# of config reading.) Replace bit by bit and see what happens?
 def read_pins(f):
     from setuptools.config import ConfigHandler
     # duplicates some earlier configparser stuff (which doesn't
@@ -241,9 +245,6 @@ def read_pins(f):
     return ConfigHandler._parse_dict(pins_raw)
 
 def read_conda_packages(f,name):
-    if name == '':
-        return []
-    
     from setuptools.config import ConfigHandler
     # duplicates some earlier configparser stuff (which doesn't
     # support py2; need to clean up)
@@ -257,17 +258,18 @@ def read_conda_packages(f,name):
     pyctdev_section = 'tool:pyctdev.conda'
     
     if pyctdev_section not in config.sections():
-        if name!='':
-            raise ValueError("Requested package name %s but not defined in setup.cfg"%name)
-        else:
-            return []
+        return []
 
     try:
         packages_raw = config.get(pyctdev_section,'packages')
     except configparser.NoOptionError:
         packages_raw = ''
 
-    return ConfigHandler._parse_list(ConfigHandler._parse_dict(packages_raw)[name])
+    try:
+        packages = ConfigHandler._parse_list(ConfigHandler._parse_dict(packages_raw)[name])
+    except KeyError:
+        packages = []
+    return packages
 
 
 def read_conda_namespace_map(f):
@@ -291,3 +293,4 @@ def read_conda_namespace_map(f):
         namespacemap_raw = ''
     
     return ConfigHandler._parse_dict(namespacemap_raw)
+

--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -264,3 +264,24 @@ def read_conda_packages(f,name):
     return ConfigHandler._parse_list(ConfigHandler._parse_dict(packages_raw)[name])
 
 
+def read_conda_namespace_map(f):
+    from setuptools.config import ConfigHandler
+    # duplicates some earlier configparser stuff (which doesn't
+    # support py2; need to clean up)
+    try:
+        import configparser
+    except ImportError:
+        import ConfigParser as configparser # python2 (also prevents dict-like access)
+    pyctdev_section = 'tool:pyctdev.conda'
+    config = configparser.ConfigParser()
+    config.read(f)
+
+    if pyctdev_section not in config.sections():
+        return {}
+
+    try:
+        namespacemap_raw = config.get(pyctdev_section,'namespace_map')
+    except configparser.NoOptionError:
+        namespacemap_raw = ''
+    
+    return ConfigHandler._parse_dict(namespacemap_raw)

--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -241,6 +241,9 @@ def read_pins(f):
     return ConfigHandler._parse_dict(pins_raw)
 
 def read_conda_packages(f,name):
+    if name == '':
+        return []
+    
     from setuptools.config import ConfigHandler
     # duplicates some earlier configparser stuff (which doesn't
     # support py2; need to clean up)
@@ -254,7 +257,10 @@ def read_conda_packages(f,name):
     pyctdev_section = 'tool:pyctdev.conda'
     
     if pyctdev_section not in config.sections():
-        return []
+        if name!='':
+            raise ValueError("Requested package name %s but not defined in setup.cfg"%name)
+        else:
+            return []
 
     try:
         packages_raw = config.get(pyctdev_section,'packages')

--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -226,7 +226,6 @@ def read_pins(f):
         import configparser
     except ImportError:
         import ConfigParser as configparser # python2 (also prevents dict-like access)
-    import re
     pyctdev_section = 'tool:pyctdev'
     config = configparser.ConfigParser()
     config.read(f)
@@ -249,7 +248,6 @@ def read_conda_packages(f,name):
         import configparser
     except ImportError:
         import ConfigParser as configparser # python2 (also prevents dict-like access)
-    import re
     config = configparser.ConfigParser()
     config.read(f)
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup_args = dict(
     name = 'pyctdev',
     description = 'python packaging common tasks for developers',
     long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",    
+    long_description_content_type="text/markdown",
     version = versioneer.get_version().lstrip('v'),
     cmdclass = versioneer.get_cmdclass(),
     license = 'BSD-3',
@@ -39,7 +39,7 @@ setup_args = dict(
 
         # Pretty much part of every python distribution now anyway.
         # Use it e.g. to be able to read pyproject.toml
-        'pip >=10'
+        'pip ==19.0.3'
     ],
     extras_require={
         'tests': ['flake8'],

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # for reasons this file is opaque.
 
 [tox]
-envlist = {py27,py36}-{unit,examples,flakes,all}-{default,with_numpy}-{dev,pkg}
+envlist = {py27,py36,py37}-{unit,examples,flakes,all}-{default,with_numpy}-{dev,pkg}
 
 [_flakes]
 commands = flake8
@@ -45,7 +45,8 @@ commands = {[_onlytox]commands}
            flakes: {[_flakes]commands}
            all: {[_all]commands}
            with_numpy: python -c "import numpy;print(numpy.__version__)"
-           py36: python -c "import sys;assert sys.version_info[0]==3;print('ok')"
+           py37: python -c "import sys;assert sys.version_info[0]==3;assert sys.version_info[1]==7;print('ok')"	   
+           py36: python -c "import sys;assert sys.version_info[0]==3;assert sys.version_info[1]==6;print('ok')"
            py27: python -c "import sys;assert sys.version_info[0]==2;print('ok')"
 
 deps = unit: {[_unit]deps}


### PR DESCRIPTION
Currently, pytdev expects python projects to use python setuptools config to declare as much common packaging info as they can (e.g. description, dependencies, etc). (Note: Although it's setuptools setup.cfg right now because support for that's all built into python and it's used anyway by conda build, it could instead be any other format, e.g. conda build meta.yaml.)

Whatever's used, though, it's probably not possible for project authors to express in only one packaging tool's existing config everything they know to help packagers. This PR allows projects to add some custom things to setup.cfg, so that project authors can give more hints to packagers. pyctdev will use those hints when packaging (where possible, depending on what kind of packages it's making). And manual/semi-manual packagers (e.g. conda-forge package maintainers) could read those hints.

## New features

  * Optional dependency version pinning. E.g. to optionally generate
    pinned packages and/or environments containing versions of
    dependencies that are known to be mutually compatible. (Conda only
    right now; should be added to pip ecosystem too.)

  * "Namespaces". E.g. because pypi name doesn't match conda main
    ("defaults") name which doesn't match conda-forge
    name. https://github.com/pyviz/pyct/issues/42.

  * Declare non-python (non-pypi) dependencies. E.g. a dependency not
    on pypi yet, or a lower level ("system") dependency that is
    unlikely ever to be on pypi. Python project authors may still know
    about constraints to be applied where possible e.g. with conda,
    apt, etc. (Currently only conda; could support other package
    managers in future.)

  * Support for multiple packages where the packaging system isn't
    like pip/pypi. E.g. conda default package might include
    everything, while pip/pypi default is minimal
    dependencies. Project can declare mapping of packages to python
    extras.

  * Can generate environment files from info in setup.cfg (not just
    actual environments). Can pin and filter dependencies (from info in 
    setup.cfg). Note: currently only conda ecosystem; should be added
    for python world too.

