### PR TITLE
Also ask pip not to install build dependencies during editable install when using conda

### DIFF
--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -108,7 +108,7 @@ CONDA_ROOT_EXE = os.environ.get('CONDA_EXE','conda') # TODO should at least warn
 
 # TODO: not sure what conda-using developers do/prefer...
 # pip develop and don't install missing deps
-python_develop = "pip install --no-deps -e ."
+python_develop = "pip install --no-deps --no-build-isolation -e ."
 # pip develop and pip install missing deps
 #  python_develop = "pip install -e ."
 # setuptools develop and don't install missing deps

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -107,7 +107,7 @@ no_pin_deps = {
 CONDA_ROOT_EXE = os.environ.get('CONDA_EXE','conda') # TODO should at least warn if conda_exe not there; will be fixed as part of 0.7
 
 # TODO: not sure what conda-using developers do/prefer...
-# pip develop and don't install missing deps
+# pip develop and don't install missing install deps or any build deps
 python_develop = "pip install --no-deps --no-build-isolation -e ."
 # pip develop and pip install missing deps
 #  python_develop = "pip install -e ."


### PR DESCRIPTION
If you `pip install -e .` when using conda, any missing dependencies are installed by pip. You can avoid that by passing `--no-deps` to the pip command. (pyctdev ecosystem=conda installs all deps using conda, so `--no-deps` just avoids pip checking all the deps and finding them all present.)

With pip now supporting build dependencies, we should also ask pip not to install the build dependencies when we're using conda. Otherwise, pip will spend time creating an isolated environment and installing all the build dependencies before running setup.py, which is at best a waste of time (as the dependencies are already available, from conda). (At worst, there could be some subtle problem or conflict, although I haven't encountered that in practice yet.)

I don't know when the 'no build isolation' option appeared - not sure if I missed it originally, or if it wasn't present in the pip of that era (also not sure if pip was installing build deps back then).