### PR TITLE
Added python -m to python_develop method in conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
   - &pip_default
     stage: test
     # (pyctdev requires itself to test itself)
-    before_install: pip install -e .
+    before_install: python -m pip install -e .
     install: doit develop_install
     script:
       - doit test_all
@@ -49,10 +49,10 @@ jobs:
     env: PYCTDEV_ECOSYSTEM=conda
     before_install:
       ## install miniconda (using git pyctdev)
-      - pip install -e . && doit miniconda_install && pip uninstall -y doit pyctdev && rm -f .doit.db
+      - python -m pip install -e . && doit miniconda_install && python -m pip uninstall -y doit pyctdev && rm -f .doit.db
       - export PATH="$HOME/miniconda/bin:$PATH"
       ## build conda package (using git pyctdev)
-      - pip install -e . && doit ecosystem_setup && doit package_build $CHANNELS && pip uninstall -y doit pyctdev && rm -f .doit.db
+      - python -m pip install -e . && doit ecosystem_setup && doit package_build $CHANNELS && python -m pip uninstall -y doit pyctdev && rm -f .doit.db
       ## install conda package to use for rest of tests
       - conda install -y --use-local pyctdev
     install: doit develop_install
@@ -73,7 +73,7 @@ jobs:
     stage: pip_dev_package
     env: PYENV_VERSION=3.7 PYPI=testpypi
     before_install:
-      - pip install -e .
+      - python -m pip install -e .
       - doit ecosystem_setup
     install: doit package_build $PKG_TEST_GROUP --formats="$PIP_FORMATS" --sdist-run-tests
     script: doit package_upload -u ceball -p $PYPIPWD --pypi ${PYPI}

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -108,7 +108,7 @@ CONDA_ROOT_EXE = os.environ.get('CONDA_EXE','conda') # TODO should at least warn
 
 # TODO: not sure what conda-using developers do/prefer...
 # pip develop and don't install missing install deps or any build deps
-python_develop = "pip install --no-deps --no-build-isolation -e ."
+python_develop = "python -m pip install --no-deps --no-build-isolation -e ."
 # pip develop and pip install missing deps
 #  python_develop = "pip install -e ."
 # setuptools develop and don't install missing deps


### PR DESCRIPTION
I have had some problem the last week or so installing panel following [this guide](https://panel.holoviz.org/developer_guide/index.html). It would install everything fine until I came to `pip install --no-deps --no-build-isolation -e .`  where it would give the message: 
```
Obtaining file:///C:/Users/shh/Desktop/test/panel
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
Installing collected packages: panel
  Attempting uninstall: panel
    Found existing installation: panel 0.10.1
    Uninstalling panel-0.10.1:
      Successfully uninstalled panel-0.10.1
  Running setup.py develop for panel
ERROR: Could not install packages due to an EnvironmentError: [WinError 5] Access is denied: 'C:\\Users\\shh\\AppData\\Local\\Temp\\pip-uninstall-d9_l6wwu\\panel.exe'
Consider using the `--user` option or check the permissions.

TaskFailed - taskid:develop_install
Command failed: 'pip install --no-deps --no-build-isolation -e .' returned 1
```
I was running this on Windows 10. After a clean install of Miniconda I can't reproduce the error. But beforehand I tried to set it up so it worked like this PR by appending the following lines to dodo.py in Panel:
``` python
import pyctdev._conda
python_develop = 'python -m pip install --no-deps --no-build-isolation -e .'
pyctdev._conda.python_develop = python_develop
```
Which successful installed panel dev without the error above on my computer. So maybe the error was related to a wrong pip, but that is just speculation from my site. 

I could also see that the same error was happening on Panels Appveyor and I wanted to test to see if it could fix it there too. Unfortunately the Appveyor was disabled on Panel before I could test to see if it would work, because of the transition to Github actions (I think). I also did find a link mentioning a somewhat similar problem [here](https://pythonhosted.org/CodeChat/appveyor.yml.html).