### PR TITLE
Fix pip toml import

### DIFF
--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -233,12 +233,18 @@ def get_dependencies(groups,all_extras=False):
 def get_buildreqs():
     try:
         import pip._vendor.pytoml as toml
-    except:
-        # pip>=20.1
-        import pip._vendor.toml as toml
+    except Exception:
+        try:
+            # pip>=20.1
+            import pip._vendor.toml as toml
+        except Exception:
+            # pip>=21.2.1
+            import pip._vendor.tomli as toml
+
     buildreqs = []
     if os.path.exists('pyproject.toml'):
-        pp = toml.load(open('pyproject.toml'))
+        with open('pyproject.toml') as f:
+            pp = toml.load(f)
         if 'build-system' in pp:
             buildreqs += pp['build-system'].get("requires",[])
     return buildreqs


### PR DESCRIPTION
`toml` is now located at `pip._vendor.tomli` instead of `pip._vendor.toml`. 

Fixed it with another try/except but I don't think the solution is pretty... So if a prettier/better way can be done this PR can be closed.  

Also added `Exception` and a context manager for this function only. 