### PR TITLE
Explicitly require toml

### DIFF
--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -231,11 +231,7 @@ def get_dependencies(groups,all_extras=False):
 
 
 def get_buildreqs():
-    try:
-        import pip._vendor.pytoml as toml
-    except:
-        # pip>=20.1
-        import pip._vendor.toml as toml
+    import toml
     buildreqs = []
     if os.path.exists('pyproject.toml'):
         pp = toml.load(open('pyproject.toml'))

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ setup_args = dict(
         # Pretty much part of every python distribution now anyway.
         # Use it e.g. to be able to read pyproject.toml
         # pinning to avoid https://github.com/pyviz/pyctdev/issues/12
-        'pip >=19.1.1'
+        'pip >=19.1.1',
+        # pip >= 21.x no longer vendors toml
+        'toml'
     ],
     extras_require={
         'tests': ['flake8'],


### PR DESCRIPTION
Latest pip no longer vendors toml so we have to require it explicitly now.