### PR TITLE
Don't install the tests extras by default when running develop_install

### DIFF
--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -83,9 +83,7 @@ _options_param = {
     'long':'options',
     'short': 'o',
     'type':list,
-    # TODO: confusing to do this, because it means no way to have
-    # none
-    'default':['tests']
+    'default':[]
 }
 
 # the hack for above default


### PR DESCRIPTION
Fixes https://github.com/pyviz-dev/pyctdev/issues/81

I've gone through the process of rebuilding the docs of a few holoviz sites and I see more and more environments failing to solve during their install process (currently hvplot and datashader) (the workflow adopted by pyctdev doesn't really help conda since it first creates an empty environment and then installs packages in that environment in multiple steps). Removing the requirements imposed by the default `tests` can only help in these situations!

I haven't found any single usage of a bare `doit develop_install` (I mean without any option) so I don't think this change will break any current CI config.