### PR TITLE
Invoke pip as a module in the conda develop_install task

### DIFF
--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -119,7 +119,7 @@ CONDA_ROOT_EXE = os.environ.get('CONDA_EXE','conda') # TODO should at least warn
 
 # TODO: not sure what conda-using developers do/prefer...
 # pip develop and don't install missing install deps or any build deps
-python_develop = "pip install --no-deps --no-build-isolation -e ."
+python_develop = "python -m pip install --no-deps --no-build-isolation -e ."
 # pip develop and pip install missing deps
 #  python_develop = "pip install -e ."
 # setuptools develop and don't install missing deps


### PR DESCRIPTION
Supersedes #75 

I've seen the error reported in #75 a few times already in Github Actions on Windows, the suggested change seems totally safe to me. Yet it's not sure this will fix the issue since its error isn't precisely known.