### PR TITLE
Don't run the two conda commands in develop_install in the shell

### DIFF
--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -882,8 +882,8 @@ def task_develop_install():
 
     """
     return {'actions': [
-        CmdAction(_conda_build_deps),
-        CmdAction(_conda_install_with_options_hacked),
+        CmdAction(_conda_build_deps, shell=False),
+        CmdAction(_conda_install_with_options_hacked, shell=False),
         python_develop],
             'params': [_options_param,_channel_param,no_pin_deps,_all_extras_param,_conda_mode_param]}
 


### PR DESCRIPTION
Datashader's CI is failing on Windows. Its `setup.py` declares `numpy >=1.7,!=1.22` and for some (still unknown, at least to me) reason the exclamation mark isn't passed down to conda which then translates it as `numpy=1.22`, exactly what we don't want!

See https://github.com/holoviz/datashader/runs/5788134696?check_suite_focus=true#step:8:149 where this commands:
```
conda install -y   "dask >=0.18.0" "datashape >=0.5.1" "numba >=0.51" "numpy >=1.7,!=1.22" "pandas >=0.24.1" "pillow >=3.1.1" "xarray >=0.9.6" "colorcet >=0.9.0" "param >=1.6.1" "pyct >=0.4.5" "scipy" "pytest >=3.9.3" "pytest-benchmark >=3.0.0" "pytest-cov" "codecov" "flake8" "nbconvert" "nbsmoke >0.5" "fastparquet >=0.1.6" "holoviews >=1.10.0" "bokeh" "pyarrow" "netcdf4" "twine" "rfc3986" "keyring" "spatialpandas" "rioxarray" "rasterio"
```

leads to:

```
    - numpy[version='>=1.7,=1.22']
```

I was able to reproduce the bug locally and fix it with the changes suggested in this PR, which sets `shell=False` to a couple of `CmdAction` calls. This class provided by `doit` internally relies on `subprocess.Popen`, with by default `shell=True`.