### PR TITLE
Add tomli as a dependency and adapt code to tomli>=2

### DIFF
--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -21,6 +21,12 @@ try:
 except ImportError:
     setuptools_version = None
 
+try:
+    import tomli as toml
+except ImportError:
+    # tomllib added to the stdlib in Python 3.11
+    import tomllib as toml
+
 toxconf = tox_config.parseconfig('tox')
 # we later filter out any _onlytox commands...
 toxconf_pre = configparser.ConfigParser()
@@ -246,19 +252,9 @@ def get_dependencies(groups,all_extras=False):
 
 
 def get_buildreqs():
-    try:
-        import pip._vendor.pytoml as toml
-    except Exception:
-        try:
-            # pip>=20.1
-            import pip._vendor.toml as toml
-        except Exception:
-            # pip>=21.2.1
-            import pip._vendor.tomli as toml
-
     buildreqs = []
     if os.path.exists('pyproject.toml'):
-        with open('pyproject.toml') as f:
+        with open('pyproject.toml', 'rb') as f:
             pp = toml.load(f)
         if 'build-system' in pp:
             buildreqs += pp['build-system'].get("requires",[])

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ setup_args = dict(
         # Pretty much part of every python distribution now anyway.
         # Use it e.g. to be able to read pyproject.toml
         # pinning to avoid https://github.com/pyviz/pyctdev/issues/12
-        'pip >=19.1.1'
+        'pip >=19.1.1',
+        # Added to no longer depend on tomli vendored by pip.
+        'tomli>=2;python_version<"3.11"',
     ],
     extras_require={
         'tests': ['flake8'],


### PR DESCRIPTION
pyctdev is using the toml library vendored by pip, `tomli`, which pip upgraded from 1.x to 2.x in its 22.1 version. The newer `tomli` apparently strictly requires to open a file with `.load` in binary mode (https://github.com/hukkin/tomli#parse-a-toml-file). This broke pyctdev.

Instead of relying on a vendored version of tomli by pip, tomli (>=2) is now a dependency of pyctdev and it will be the case until Python 3.11, which will offer the `tomllib` module (adapted from tomli, same API then).