### PR TITLE
Simplify tomli dependency

### DIFF
--- a/pyctdev/util.py
+++ b/pyctdev/util.py
@@ -3,6 +3,8 @@ import os
 import itertools
 import configparser
 
+import tomli as toml
+
 # Fallbacks for conda, which can't install tox from defaults (at
 # least, not as of June 2018). Allows to parse tox.ini (i.e. to use
 # tox.ini as single place where all test cmds and envs are stored)
@@ -20,12 +22,6 @@ try:
     setuptools_version = Version(setuptools.__version__)
 except ImportError:
     setuptools_version = None
-
-try:
-    import tomli as toml
-except ImportError:
-    # tomllib added to the stdlib in Python 3.11
-    import tomllib as toml
 
 toxconf = tox_config.parseconfig('tox')
 # we later filter out any _onlytox commands...

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup_args = dict(
         # pinning to avoid https://github.com/pyviz/pyctdev/issues/12
         'pip >=19.1.1',
         # Added to no longer depend on tomli vendored by pip.
-        'tomli>=2;python_version<"3.11"',
+        'tomli',
     ],
     extras_require={
         'tests': ['flake8'],


### PR DESCRIPTION
* conda-build doesn't seem to support `python_version` in `install_requires`
* tomli 2 isn't yet available on the default channel so let's be less strict