### PR TITLE
Merge build and runtime deps install commands

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Removed semi-colons from the entire codebase
+07e059ae6c2b8d2e7faf548715d01b544b68a001

--- a/pyctdev/_conda.py
+++ b/pyctdev/_conda.py
@@ -288,10 +288,8 @@ def _conda_install_build_runtime_extras(
     if len(deps) > 0:
         deps = " ".join('"%s"' % dep for dep in deps)
         # TODO and join the club?
-        e = "" if env_name_again == "" else "-n %s" % env_name_again
         cmd = (
             "%s install -y " % (conda_mode)
-            + e
             + " %s %s" % (" ".join(["-c %s" % c for c in channel]), deps)
         )
         print("Install build/runtime/extras dependencies with:", cmd)


### PR DESCRIPTION
This had two effects:
- it slowed down the install
- could cause Python to be updated in between the two calls, leading to doit reporting a failure but without an explicit error

This PR merges the build and runtime deps install commands into a single command. It might lead to slightly different solve results though.